### PR TITLE
M5 - No Duplicate Guard in save_lti_type_backup

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1269,6 +1269,12 @@ function block_onlinesurvey_create_lti_type()
 
 function block_onlinesurvey_save_lti_type_backup($typeid) {
     global $DB;
+
+    if ($DB->record_exists('block_onlinesurvey_lti_types', ['originaltypeid' => $typeid])) {
+        block_onlinesurvey_update_lti_type_backup($typeid);
+        return;
+    }
+
     $record = $DB->get_record('lti_types', ['id' => $typeid]);
     if (!$record) {
         return;


### PR DESCRIPTION
Fixes `M5 - No Duplicate Guard in save_lti_type_backup ` in issue #80 

The function `block_onlinesurvey_save_lti_type_backup` is currently only ever called after a new lti_type was created, therefore the case of an already existing backup with the same typeid can't be hit. Nevertheless I added a check to make sure no lti_type backup for that typeid exists yet. If we find a backup we use the update function to update it.