### PR TITLE
Fix wrong function beeing used in failure path for block_onlinesurvey…

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1288,7 +1288,7 @@ function block_onlinesurvey_update_lti_type_backup($typeid) {
     global $DB;
     $oldRecord = $DB->get_record('block_onlinesurvey_lti_types', ['originaltypeid' => $typeid]);
     if (!$oldRecord) {
-        block_onlinesurvey_restore_deleted_lti_type($typeid);
+        block_onlinesurvey_save_lti_type_backup($typeid);
         return;
     }
     $ltitype = $DB->get_record('lti_types', ['id' => $typeid]);


### PR DESCRIPTION
Restoring the backup after just finding out we don't have a backup doesn't make sense.
What propably was intended is to initaly save a backup when finding out we don't have a backup during trying to update the backup.