### PR TITLE
H4 - Skip health check if we arent configured yet or dont use lti

### DIFF
--- a/block_onlinesurvey.php
+++ b/block_onlinesurvey.php
@@ -180,7 +180,10 @@ class block_onlinesurvey extends block_base {
         if ($this->content !== null) {
             return $this->content;
         }
-        block_onlinesurvey_check_lti_exists();
+        if ($this->isconfigured && $this->moodleuserid &&
+                ($config->connectiontype == 'LTI' || $config->connectiontype == LTI_VERSION_1P3)) {
+            block_onlinesurvey_check_lti_exists();
+        }
 
         $this->content = new stdClass();
         $this->content->text = '';


### PR DESCRIPTION
Skip checking lti exists if we aren't configured yet or don't use lti adressing `H4 - Database Health-Check on Every Page ` in issue #80 
The success path of the health check consist of a get_config() and a small DB query, which I think isn't excessive for a block beeing renderd.
The failure path results in a restore attempt, which is by design in this plugin and shouldn't occure repeatedly after the first execution.